### PR TITLE
Fix scrambleKey in decorateAppAPIMethods

### DIFF
--- a/src/Common.ts
+++ b/src/Common.ts
@@ -46,7 +46,7 @@ export class Common {
     transport.decorateAppAPIMethods(
       this,
       ["menu", "getPublicKey", "signTransaction", "getVersion"],
-      "KDA"
+      scrambleKey
     );
   }
 


### PR DESCRIPTION
I believe this was a typo and the scrambleKey should have been used